### PR TITLE
SCRAPER: Auto-throttling rate limit

### DIFF
--- a/server/scraper/scraper/settings.py
+++ b/server/scraper/scraper/settings.py
@@ -19,13 +19,18 @@ ROBOTSTXT_OBEY = True
 # Reduce log verbosity from 'DEBUG'
 LOG_LEVEL = "INFO"
 
+# Vary Delay time between requests to decrease chance of detection
+AUTOTHROTTLE_ENABLED = True
+AUTOTHROTTLE_START_DELAY = 2
+AUTOTHROTTLE_MAX_DELAY = 10
+
 # Configure maximum concurrent requests performed by Scrapy (default: 16)
 #CONCURRENT_REQUESTS = 32
 
 # Configure a delay for requests for the same website (default: 0)
 # See https://docs.scrapy.org/en/latest/topics/settings.html#download-delay
 # See also autothrottle settings and docs
-#DOWNLOAD_DELAY = 3
+# DOWNLOAD_DELAY = 3
 # The download delay setting will honor only one of:
 #CONCURRENT_REQUESTS_PER_DOMAIN = 16
 #CONCURRENT_REQUESTS_PER_IP = 16


### PR DESCRIPTION
Introduced a limit on the speed in which our scraper can make requests. I did this using the auto-throttling setting from the Scrapy library, docs here:

https://docs.scrapy.org/en/latest/topics/autothrottle.html

With this change, the scraper will automatically adjust its speed based on how quickly the server responds. It will begin at a 
2 second delay and increase up to a 10 second delay. These numbers may need to be adjusted later but this is a good start. 